### PR TITLE
Adding initial support for query parameters and using existing stack …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     </parent>
 
     <properties>
-        <version.zeebe>0.20.0</version.zeebe>
+        <version.zeebe>0.21.0</version.zeebe>
 
         <!-- release parent settings -->
         <version.java>11</version.java>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.9</version>
+            <version>2.10.0</version>
         </dependency>
 
         <!-- logging -->
@@ -65,6 +65,12 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.11.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.5</version>
         </dependency>
 
         <!-- test -->

--- a/src/main/java/io/zeebe/http/HttpJobHandler.java
+++ b/src/main/java/io/zeebe/http/HttpJobHandler.java
@@ -135,7 +135,14 @@ public class HttpJobHandler implements JobHandler {
       for (NameValuePair tokenizedQueryParam : tokenizedQueryParams) {
 
         String queryParamName = tokenizedQueryParam.getName();
-        String queryParamTokenizedValue = tokenizedQueryParam.getValue().replaceFirst("\\$", "");
+        String queryParamValue = tokenizedQueryParam.getValue();
+
+        if (!queryParamValue.startsWith("$")) {
+          // nothing to resolve
+          continue;
+        }
+
+        String queryParamTokenizedValue = queryParamValue.replaceFirst("\\$", "");
         String queryParamResolvedValue = resolveContextVariable(queryParamTokenizedValue, variables).toString();
 
         TokenizedQueryParameterNameValuePair resolvedQueryParamNameValuePair = new TokenizedQueryParameterNameValuePair(

--- a/src/main/java/io/zeebe/http/InvalidJsonPathException.java
+++ b/src/main/java/io/zeebe/http/InvalidJsonPathException.java
@@ -1,0 +1,8 @@
+package io.zeebe.http;
+
+public class InvalidJsonPathException extends Exception {
+
+	public InvalidJsonPathException(String message){
+		super(message);
+	}
+}

--- a/src/main/java/io/zeebe/http/ZeebeHttpWorker.java
+++ b/src/main/java/io/zeebe/http/ZeebeHttpWorker.java
@@ -39,7 +39,11 @@ public class ZeebeHttpWorker {
             .build();
 
     final HttpJobHandler jobHandler = new HttpJobHandler();
-    jobWorker = client.newWorker().jobType("http").handler(jobHandler).fetchVariables(HttpJobHandler.VARIABLE_NAMES).open();
+    jobWorker = client.newWorker()
+            .jobType("http")
+            .handler(jobHandler)
+            /* .fetchVariables(HttpJobHandler.VARIABLE_NAMES) */ // Fetching a limited set of variables limits ability to use variables in stack
+            .open();
   }
 
   public void stop() {

--- a/src/test/java/io/zeebe/http/HttpJobHandlerTests.java
+++ b/src/test/java/io/zeebe/http/HttpJobHandlerTests.java
@@ -1,0 +1,40 @@
+package io.zeebe.http;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpJobHandlerTests {
+
+	@Test
+	public void shouldResolveSingleTokenizedQueryParameterFromVariables(){
+
+		HttpJobHandler sut = new HttpJobHandler();
+
+		String url = "http://localhost:7200/api/posts?postid=$postid";
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("postid", 1);
+
+		url = sut.resolveQueryParameters(url, variables);
+
+		Assert.assertEquals("http://localhost:7200/api/posts?postid=1", url);
+	}
+
+	@Test
+	public void shouldResolveeMultipleTokenizedQueryParametersFromVariables(){
+
+		HttpJobHandler sut = new HttpJobHandler();
+
+		String url = "http://localhost:7200/api/posts?postid=$postid&commentid=$commentid&userid=$userid";
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("postid", 1);
+		variables.put("commentid", "c1");
+		variables.put("userid", "john.doe");
+
+		url = sut.resolveQueryParameters(url, variables);
+
+		Assert.assertEquals("http://localhost:7200/api/posts?postid=1&commentid=c1&userid=john.doe", url);
+	}
+}

--- a/src/test/java/io/zeebe/http/HttpJobHandlerTests.java
+++ b/src/test/java/io/zeebe/http/HttpJobHandlerTests.java
@@ -37,4 +37,19 @@ public class HttpJobHandlerTests {
 
 		Assert.assertEquals("http://localhost:7200/api/posts?postid=1&commentid=c1&userid=john.doe", url);
 	}
+
+	@Test
+	public void shouldNotAttemptToResolveeNonTokenizedQueryParameters(){
+
+		HttpJobHandler sut = new HttpJobHandler();
+
+		String url = "http://localhost:7200/api/posts?postid=$postid&userid=john.doe";
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("postid", 1);
+		variables.put("userid", "john.doe");
+
+		url = sut.resolveQueryParameters(url, variables);
+
+		Assert.assertEquals("http://localhost:7200/api/posts?postid=1&userid=john.doe", url);
+	}
 }

--- a/src/test/java/io/zeebe/http/WorkflowTest.java
+++ b/src/test/java/io/zeebe/http/WorkflowTest.java
@@ -1,17 +1,10 @@
 package io.zeebe.http;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.zeebe.client.ZeebeClient;
 import io.zeebe.client.api.response.WorkflowInstanceEvent;
 import io.zeebe.model.bpmn.Bpmn;
 import io.zeebe.model.bpmn.BpmnModelInstance;
-import io.zeebe.protocol.record.intent.MessageIntent;
-import io.zeebe.protocol.record.value.MessageRecordValue;
 import io.zeebe.test.ZeebeTestRule;
-import io.zeebe.test.util.record.RecordingExporter;
-
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -244,6 +237,8 @@ public class WorkflowTest {
             .hasVariable("statusCode", 201)
             .hasVariable("body", expectedResponse);
   }
+
+
 
   @Test
   public void shouldExecutePutRequest() {


### PR DESCRIPTION
…variables.  Also included ability to use existing stack/workflow variables as HTTP post body.

The usage pattern is as follows:  

When modeling a HTTP endpoint, such as a GET request, one can specify a url like this as part of the custom header:

https://jsonplaceholder.typicode.com/comments?postId=**$context.postQueryParams.postId**

The highlighted part refers to the JSON path of a simple context variable in the workflow stack.

Also added is the ability to use a custom header to specify a variable to be used context of the HTTP POST body.  For example, if in your model you specify a custom header using the keyword 
**_postBodyVariableName_** and value **_context.todo_** which represents a JSON path to the object, this will be used as the content of the HTTP post body.