### PR TITLE
throw error on failed response

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Example BPMN with service task:
   * `method` - the HTTP method to use (default: `GET`, allowed:  `post` | `get` | `put` | `delete` | `patch`)
   * `statusCodeCompletion` - Status codes that lead to completion of the service task (default: `1xx,2xx`, allowed: comma separated list of codes including 1xx, 2xx, 3xx, 4xx and 5xx)
   * `statusCodeFailure` - Status codes that lead to the job failing  (default: `3xx,4xx,5xx`, allowed: comma separated list of codes including 1xx, 2xx, 3xx, 4xx and 5xx)
-  * `errorCodePath` - Variable expression (dot notation) applied over a failed response body to throw a Zeebe error. If the value can't be found or this headers isn't configured, the job fails.
-  * `errorMessagePath` - Variable expression (dot notation) applied over a failed response body to extract a custom error message.
+  * `errorCodePath` - path expression (dot notation) to extract the error code of a failed response body (e.g. `error.code`). If the error code is present then a BPMN error is thrown with this code instead of failing the job. Otherwise, that leads to the job failing.
+  * `errorMessagePath` - path expression (dot notation) to extract the error message of a failed response body (e.g. `error.message`). If the error message is present then it is used as the error message of the BPMN error. Otherwise, a default error message is used.
   
 * optional variables:
   * `body` - the request body as JSON

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Example BPMN with service task:
   * `method` - the HTTP method to use (default: `GET`, allowed:  `post` | `get` | `put` | `delete` | `patch`)
   * `statusCodeCompletion` - Status codes that lead to completion of the service task (default: `1xx,2xx`, allowed: comma separated list of codes including 1xx, 2xx, 3xx, 4xx and 5xx)
   * `statusCodeFailure` - Status codes that lead to the job failing  (default: `3xx,4xx,5xx`, allowed: comma separated list of codes including 1xx, 2xx, 3xx, 4xx and 5xx)
+  * `errorCodePath` - Variable expression (dot notation) applied over a failed response body to throw a Zeebe error. If the value can't be found or this headers isn't configured, the job fails.
+  * `errorMessagePath` - Variable expression (dot notation) applied over a failed response body to extract a custom error message.
   
 * optional variables:
   * `body` - the request body as JSON

--- a/src/test/java/io/zeebe/http/WorkflowTest.java
+++ b/src/test/java/io/zeebe/http/WorkflowTest.java
@@ -1,7 +1,7 @@
 package io.zeebe.http;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -262,8 +262,7 @@ public class WorkflowTest {
         .withWorkflowInstanceKey(workflowInstance.getWorkflowInstanceKey())
         .getFirst();
     
-    assertNotNull(recorderJob.getValue().getErrorMessage());
-    assertTrue("Error message contains status code 400: " + recorderJob.getValue().getErrorMessage(), recorderJob.getValue().getErrorMessage().contains("failed with 400"));     
+    assertThat(recorderJob.getValue().getErrorMessage()).isNotNull().contains("failed with 400");
   }
 
   @Test
@@ -283,9 +282,8 @@ public class WorkflowTest {
         .withWorkflowInstanceKey(workflowInstance.getWorkflowInstanceKey())
         .getFirst();
 
-    assertNotNull(recorderJob.getValue().getErrorCode());
-    assertEquals("some-code", recorderJob.getValue().getErrorCode());
-    assertEquals("some message", recorderJob.getValue().getErrorMessage());
+    assertThat(recorderJob.getValue().getErrorCode()).isNotNull().isEqualTo("some-code");
+    assertThat(recorderJob.getValue().getErrorMessage()).isNotNull().isEqualTo("some message");
   }
 
   @Test
@@ -305,9 +303,8 @@ public class WorkflowTest {
         .withWorkflowInstanceKey(workflowInstance.getWorkflowInstanceKey())
         .getFirst();
 
-    assertNotNull(recorderJob.getValue().getErrorCode());
-    assertEquals("some-code", recorderJob.getValue().getErrorCode());
-    assertTrue("Error message contains status code 400: " + recorderJob.getValue().getErrorMessage(), recorderJob.getValue().getErrorMessage().contains("failed with 400"));
+    assertThat(recorderJob.getValue().getErrorCode()).isNotNull().isEqualTo("some-code");
+    assertThat(recorderJob.getValue().getErrorMessage()).isNotNull().contains("failed with 400");
   }
 
   @Test
@@ -327,8 +324,7 @@ public class WorkflowTest {
         .withWorkflowInstanceKey(workflowInstance.getWorkflowInstanceKey())
         .getFirst();
 
-    assertNotNull(recorderJob.getValue().getErrorMessage());
-    assertEquals("some message", recorderJob.getValue().getErrorMessage());
+    assertThat(recorderJob.getValue().getErrorMessage()).isNotNull().contains("some message");
   }
 
   @Test
@@ -348,8 +344,7 @@ public class WorkflowTest {
         .withWorkflowInstanceKey(workflowInstance.getWorkflowInstanceKey())
         .getFirst();
 
-    assertNotNull(recorderJob.getValue().getErrorMessage());
-    assertTrue("Error message contains status code 400: " + recorderJob.getValue().getErrorMessage(), recorderJob.getValue().getErrorMessage().contains("failed with 400"));
+    assertThat(recorderJob.getValue().getErrorMessage()).isNotNull().contains("failed with 400");
   }
 
   @Test


### PR DESCRIPTION
Hi, this pull request adds support to throw a Zeebe error if the HTTP response was a failure.

There are two new optional header configs:
- `errorCodePath`: Variable expression (dot separated) to extract the error code from a failed response Json body. If the path can be found, a throw error command (with the extracted error code) will be sent. In any other case it will continue with the previous behaviour (fail command).
- `errorMessagePath`: Variable expression (dot separated) to extract the error message from a failed response Json body. If the error code is configured and found, it will be used as the throw error command message. If not, it will be used as the error message of the failure. If not configured or not found, it will continue sending the previously defined error message.

There is no need to define both headers all the time, they can be independently used.

### Usage example:

#### Workflow
![Screen Shot 2020-03-06 at 16 32 59](https://user-images.githubusercontent.com/2966682/76119028-45128f00-5fcd-11ea-9a06-fb9137ad5faf.png)

#### `Duplicated` error handler
- Error code: `item-duplicated`

#### `Register Item` Headers
- `url`: `http://some-service/etc/etc`
- `method`: `post`
- `errorCodePath`: `error.code`
- `errorMessagePath`: `error.message`

#### HTTP Response 400
```json
{
  "data": null,
  "error": {
    "code": "item-duplicated",
    "message": "The item '123' is already registered."
  }
}
```

#### Next Step
The workflow instance will continue on `Notify User`.